### PR TITLE
Pin just-the-docs to 0.10.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 ruby "3.4.6"
 
 gem "jekyll"
-gem "just-the-docs"
+gem "just-the-docs", "0.10.2"
 gem "jekyll-target-blank", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.18.0)
-    just-the-docs (0.11.1)
+    just-the-docs (0.10.2)
       jekyll (>= 3.8.5)
       jekyll-include-cache
       jekyll-seo-tag (>= 2.0)
@@ -153,7 +153,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   jekyll-target-blank (~> 2.0)
-  just-the-docs
+  just-the-docs (= 0.10.2)
 
 RUBY VERSION
    ruby 3.4.6p54

--- a/_config.yml
+++ b/_config.yml
@@ -7,9 +7,9 @@ search_enabled: true
 color_scheme: massnordic
 permalink: pretty
 callouts:
-  notice_yellow:
+  highlight:
     color: yellow
-  notice_blue:
+  update:
     title: Update
     color: blue    
 plugins:

--- a/content/index.md
+++ b/content/index.md
@@ -24,7 +24,7 @@ partners to strengthen racing and development statewide.
 
 ## MA Nordic Cup
 
-{: .notice_blue }
+{: .update }
 > **8:45am, Wed, Jan. 21, 2026:** The Mass Nordic race committee and race jury will be meeting at 8:30pm this evening to discuss logistics of the race this coming Sunday. With the forecasted cold weather and snow, we need to take in consideration the health and well being of the athletes and volunteers. Once a decision has been made, we will send out an email update as well as post it to our website, MassNordic.org, and SkiReg page.
 
 The [2026 MA Nordic Cup]({% link ma-nordic-cup/index.md %}) is Sun, Jan. 25, 2026, at Prospect Mountain in Woodford, VT. **Skiers must register for this race to be considered for the U16 or EHS Championship teams**. Skiers who wish to be considered but are unable to participate in the race may apply for a waiver through their coach, but are still required to register. See [Qualifying for Team MA]({% link qualification/index.md %}) for details.

--- a/content/qualification/coaches-guide.md
+++ b/content/qualification/coaches-guide.md
@@ -38,7 +38,7 @@ Athletes who anticipate being unable to enter one or both races of the MA Nordic
 
 Public and private high school races, Eastern Cups, the MA Nordic Cup, and other statewide races are scored for MA Nordic Points. Every athlete who's registered for the MA Nordic Cup receives points for finishing any of those races.
 
-{: .notice_yellow }
+{: .highlight }
 Completing the skate and classic races at the MA Nordic Cup is sufficient to meet the racing requirements for championship team selection. Additional racing beyond the MA Nordic Cup can only improve, not hurt, an athlete's point average.
 
 
@@ -68,7 +68,7 @@ Waivers may be granted for illness or injury on the day of the event, for family
 
 The Mass Nordic Board reviews waiver requests and communicates decisions to the athlete and coach. 
 
-{: .notice_yellow }
+{: .highlight }
 Athletes who miss one or both races at the MA Nordic Cup with an approved waiver should plan to race *at least* one scored classic and one scored skate race over the course of the season. Doing so will place them on the MA Ranking List (MRL) and maintain their eligibility to be selected on objective criteria. Athletes who do not complete scored races in both techniques are eligible for team naming only as discretionary selections.
 
 ## Data submission and review

--- a/content/qualification/index.md
+++ b/content/qualification/index.md
@@ -35,7 +35,7 @@ The MA Nordic Cup is the central pillar of qualification for U16 and EHS teams. 
 
 To be eligible for team naming, skiers must register for and compete in the MA Nordic Cup unless a waiver is approved in advance. Even skiers with an approved waiver must still register for the MA Nordic Cup.
 
-{: .notice_yellow }
+{: .highlight }
 The MA Nordic Cup includes one scored classic race and one scored skate race. Completing the full Cup alone is sufficient to meet the racing requirements for championship team selection.
 
 ## Earning MA Nordic Points

--- a/content/qualification/technical-reference.md
+++ b/content/qualification/technical-reference.md
@@ -60,7 +60,7 @@ The Mass Nordic Board reviews waiver requests and communicates decisions to the 
 
 Waivers excuse participation in the MA Nordic Cup only. They do not change the racing requirements for inclusion on the MA Ranking List (MRL). To appear on the MRL, skiers must complete at least one scored classic race and one scored skate race.
 
-{: .notice_yellow }
+{: .highlight }
 Skiers who do not meet the one-classic, one-skate racing requirement do not appear on the MRL and may only be considered for team selection through discretionary selection.
 
 
@@ -107,7 +107,7 @@ Inclusion on the MA Ranking List requires completion of at least one scored clas
 
 *If a skier has MA Nordic Cup points in a technique*, their technique average is based on four values. The MA Nordic Cup points are always counted once. The best points from up to three other eligible races are counted once each, but only when they are better than the Cup result. If fewer than three such improvements exist, the remaining slots are filled using the Cup points. The technique average is the average of the four resulting values.
 
-{: .notice_yellow}
+{: .highlight}
 For skiers who have MA Nordic Cup points in a technique, additional races in that technique can only improve the technique average when they produce better points than the Cup result. Weaker results are not counted once stronger results are available. As a result, the decision to race beyond the MA Nordic Cup cannot in itself worsen a skier’s technique average or overall MA Ranking List position.
 
 


### PR DESCRIPTION
Some CSS functionality breaks on Jekyll 0.11 -- revert to 0.10